### PR TITLE
build(deps): bump Rails to 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    sidekiq-job_monitor (0.1.3)
-      rails (>= 4.0, <= 6.1)
+    sidekiq-job_monitor (0.2.0)
+      rails (>= 4.0, < 7.1)
       sidekiq (>= 5.0)
 
 GEM
@@ -160,4 +160,4 @@ DEPENDENCIES
   sidekiq-job_monitor!
 
 BUNDLED WITH
-   1.11.2
+   2.4.14

--- a/lib/sidekiq/job_monitor/version.rb
+++ b/lib/sidekiq/job_monitor/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module JobMonitor
-    VERSION = '0.1.2'
+    VERSION = '0.2.0'
   end
 end

--- a/sidekiq-job_monitor.gemspec
+++ b/sidekiq-job_monitor.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', '>= 4.0', '<= 6.1'
+  s.add_dependency 'rails', '>= 4.0', '< 7.1'
   s.add_dependency 'sidekiq', '>= 5.0'
 end


### PR DESCRIPTION
# build(deps): bump Rails to 7

![ruby logo](https://img.shields.io/badge/Ruby-informational?style=flat&logo=ruby&logoColor=white&color=CC0000)

## 🗃 Carte(s) Trello

- [Rails 6.1 ➡️ 7.0](https://trello.com/c/fkuOrI39)

## ⚙️ Back

- Bump gemspec dependency to Rails 7

## 📺 Comment tester

- In your main project Gemfile, use:

```
gem 'sidekiq-job_monitor', '0.2.0', git: 'https://github.com/Kinoba/sidekiq-job_monitor.git', branch: 'build/bump-rails-dependency-to-7'
```
